### PR TITLE
Fix login to use local server and text field values

### DIFF
--- a/lib/custom_code/actions/login_usuario.dart
+++ b/lib/custom_code/actions/login_usuario.dart
@@ -11,7 +11,7 @@ import 'package:http/http.dart' as http;
 
 Future<bool> loginUsuario(String usuario, String contrasena) async {
   final response = await http.post(
-    Uri.parse('http://192.168.1.136:8000/login'),
+    Uri.parse('http://localhost:8000/login'),
     headers: {'Content-Type': 'application/json'},
     body: json.encode({
       // el backend espera la clave "email"

--- a/lib/pages/onboarding/sign_in/sign_in_widget.dart
+++ b/lib/pages/onboarding/sign_in/sign_in_widget.dart
@@ -348,8 +348,8 @@ class _SignInWidgetState extends State<SignInWidget> {
                                       onPressed: () async {
                                         _model.resultado =
                                             await actions.loginUsuario(
-                                          FFAppState().email,
-                                          FFAppState().contrasena,
+                                          _model.emailAddressTextController.text,
+                                          _model.passwordTextController.text,
                                         );
                                         if (_model.resultado == true) {
                                           context.pushNamed(


### PR DESCRIPTION
## Summary
- adjust custom action `loginUsuario` to use localhost server
- login screen now sends input field values directly

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68518fe677a88330adc37e96c439bb2c