### PR TITLE
Add registration endpoint and Flutter integration

### DIFF
--- a/lib/custom_code/actions/index.dart
+++ b/lib/custom_code/actions/index.dart
@@ -1,3 +1,4 @@
 export 'generar_pin.dart' show generarPin;
 export 'login_usuario.dart' show loginUsuario;
 export 'generate_strong_password.dart' show generateStrongPassword;
+export 'register_usuario.dart' show registerUsuario;

--- a/lib/custom_code/actions/register_usuario.dart
+++ b/lib/custom_code/actions/register_usuario.dart
@@ -1,0 +1,30 @@
+// Automatic FlutterFlow imports
+import '/flutter_flow/flutter_flow_theme.dart';
+import '/flutter_flow/flutter_flow_util.dart';
+import 'index.dart'; // Imports other custom actions
+import 'package:flutter/material.dart';
+// Begin custom action code
+// DO NOT REMOVE OR MODIFY THE CODE ABOVE!
+
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+
+Future<bool> registerUsuario(String nombre, String telefono, String email, String contrasena) async {
+  final response = await http.post(
+    Uri.parse('http://192.168.1.136:8000/register'),
+    headers: {'Content-Type': 'application/json'},
+    body: json.encode({
+      'nombre': nombre,
+      'telefono': telefono,
+      'email': email,
+      'contrasena': contrasena,
+    }),
+  );
+
+  if (response.statusCode == 200) {
+    final data = json.decode(response.body);
+    return data['success'] ?? false;
+  } else {
+    throw Exception('Error al registrar usuario');
+  }
+}

--- a/lib/pages/onboarding/create_profile/create_profile_widget.dart
+++ b/lib/pages/onboarding/create_profile/create_profile_widget.dart
@@ -449,7 +449,21 @@ class _CreateProfileWidgetState extends State<CreateProfileWidget> {
                               0.0, 24.0, 0.0, 0.0),
                           child: FFButtonWidget(
                             onPressed: () async {
-                              context.pushNamed(HomePageWidget.routeName);
+                              final success = await actions.registerUsuario(
+                                _model.yourNameTextController.text,
+                                _model.cityTextController1.text,
+                                _model.cityTextController2.text,
+                                _model.textController4.text,
+                              );
+                              if (success) {
+                                context.pushNamed(HomePageWidget.routeName);
+                              } else {
+                                ScaffoldMessenger.of(context).showSnackBar(
+                                  SnackBar(
+                                    content: Text('Error al registrar usuario'),
+                                  ),
+                                );
+                              }
                             },
                             text: 'Registrar',
                             options: FFButtonOptions(

--- a/server/server.js
+++ b/server/server.js
@@ -45,6 +45,23 @@ const pool = mysql.createPool({
   queueLimit: 0,
 });
 
+// POST /register
+app.post('/register', async (req, res) => {
+  const { nombre, telefono, email, contrasena } = req.body;
+
+  try {
+    await pool.query(
+      'INSERT INTO usuarios (nombre, telefono, email, contraseña) VALUES (?, ?, ?, ?)',
+      [nombre, telefono, email, contrasena]
+    );
+
+    res.json({ success: true });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ success: false, message: 'Error al registrar usuario' });
+  }
+});
+
 // POST /login
 app.post('/login', async (req, res) => {
   // accept both `usuario` and `email` to be more robust


### PR DESCRIPTION
## Summary
- implement `/register` API to create new users
- add Flutter action to call the new endpoint
- invoke registration from create profile page

## Testing
- `npm install`
- `node server.js` (manual start)

------
https://chatgpt.com/codex/tasks/task_e_6851beaa6b1483309f6064c2c28104cc