### PR TITLE
Add Express passwords route snippet

### DIFF
--- a/server/encryption.js
+++ b/server/encryption.js
@@ -1,0 +1,18 @@
+const crypto = require('crypto');
+
+const algorithm = 'aes-256-cbc';
+const secretKey = crypto
+  .createHash('sha256')
+  .update(String(process.env.ENCRYPTION_KEY || 'default_secret'))
+  .digest('base64')
+  .substr(0, 32);
+const iv = Buffer.alloc(16, 0);
+
+function cifrarTexto(texto) {
+  const cipher = crypto.createCipheriv(algorithm, secretKey, iv);
+  let encrypted = cipher.update(texto, 'utf8', 'base64');
+  encrypted += cipher.final('base64');
+  return encrypted;
+}
+
+module.exports = { cifrarTexto };

--- a/server/passwords_route_snippet.js
+++ b/server/passwords_route_snippet.js
@@ -1,0 +1,56 @@
+require('dotenv').config();
+const express = require('express');
+const mysql = require('mysql2/promise');
+const { cifrarTexto } = require('./encryption');
+
+const app = express();
+app.use(express.json());
+
+const pool = mysql.createPool({
+  host: process.env.DB_HOST,
+  user: process.env.DB_USER,
+  password: process.env.DB_PASSWORD,
+  database: process.env.DB_NAME,
+  waitForConnections: true,
+  connectionLimit: 10,
+  queueLimit: 0,
+});
+
+app.post('/passwords', async (req, res) => {
+  const { usuario_id, servicio, clave_plana } = req.body;
+  const id = parseInt(usuario_id, 10);
+
+  if (!Number.isInteger(id)) {
+    return res.status(400).json({
+      success: false,
+      message: 'usuario_id debe ser un entero válido',
+    });
+  }
+
+  try {
+    const claveCifrada = cifrarTexto(clave_plana);
+    await pool.query(
+      'INSERT INTO contraseñas (usuario_id, servicio, clave_cifrada) VALUES (?, ?, ?)',
+      [id, servicio, claveCifrada]
+    );
+    res.json({ success: true });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ success: false, message: 'Error al guardar contraseña' });
+  }
+});
+
+/*
+Ejemplo de llamada fetch desde el navegador:
+fetch('http://localhost:8000/passwords', {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify({
+    usuario_id: 1,
+    servicio: 'Correo',
+    clave_plana: 'mi_clave_super_secreta',
+  }),
+})
+  .then((r) => r.json())
+  .then((data) => console.log(data));
+*/


### PR DESCRIPTION
## Summary
- add helper `cifrarTexto` in `server/encryption.js`
- add standalone snippet `passwords_route_snippet.js` implementing `POST /passwords`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6851dceae8b88330881629962e34e91a