### PR TITLE
Add email format validation

### DIFF
--- a/lib/custom_code/actions/index.dart
+++ b/lib/custom_code/actions/index.dart
@@ -2,3 +2,4 @@ export 'generar_pin.dart' show generarPin;
 export 'login_usuario.dart' show loginUsuario;
 export 'generate_strong_password.dart' show generateStrongPassword;
 export 'register_usuario.dart' show registerUsuario;
+export 'validar_email.dart' show validarEmail;

--- a/lib/custom_code/actions/validar_email.dart
+++ b/lib/custom_code/actions/validar_email.dart
@@ -1,0 +1,30 @@
+// Automatic FlutterFlow imports
+import '/flutter_flow/flutter_flow_theme.dart';
+import '/flutter_flow/flutter_flow_util.dart';
+import 'index.dart';
+import 'package:flutter/material.dart';
+// Begin custom action code
+// DO NOT REMOVE OR MODIFY THE CODE ABOVE!
+
+bool validarEmail(String email) {
+  if (email.contains(' ')) return false;
+  if (!email.contains('@')) return false;
+  final parts = email.split('@');
+  if (parts.length != 2) return false;
+  final local = parts[0];
+  final domain = parts[1];
+  if (local.isEmpty || local.length > 64) return false;
+  if (domain.isEmpty || domain.length > 255) return false;
+  if (local.startsWith('.') || local.endsWith('.')) return false;
+  if (!RegExp(r'^[A-Za-z0-9.]+$').hasMatch(local)) return false;
+  final localParts = local.split('.');
+  if (localParts.any((p) => p.isEmpty)) return false;
+  if (domain.startsWith('-') || domain.endsWith('-')) return false;
+  final domainParts = domain.split('.');
+  if (domainParts.length < 2) return false;
+  for (final part in domainParts) {
+    if (part.startsWith('-') || part.endsWith('-')) return false;
+    if (!RegExp(r'^[A-Za-z0-9-]+$').hasMatch(part)) return false;
+  }
+  return true;
+}

--- a/lib/pages/onboarding/create_profile/create_profile_widget.dart
+++ b/lib/pages/onboarding/create_profile/create_profile_widget.dart
@@ -345,8 +345,13 @@ class _CreateProfileWidgetState extends State<CreateProfileWidget> {
                                 useGoogleFonts: !FlutterFlowTheme.of(context)
                                     .bodyMediumIsCustom,
                               ),
-                          validator: _model.cityTextController2Validator
-                              .asValidator(context),
+                          validator: (value) {
+                            if (value == null ||
+                                !actions.validarEmail(value)) {
+                              return 'Email no valido';
+                            }
+                            return null;
+                          },
                         ),
                       ),
                       Padding(

--- a/lib/pages/onboarding/sign_in/sign_in_widget.dart
+++ b/lib/pages/onboarding/sign_in/sign_in_widget.dart
@@ -209,9 +209,13 @@ class _SignInWidgetState extends State<SignInWidget> {
                                               !FlutterFlowTheme.of(context)
                                                   .bodyMediumIsCustom,
                                         ),
-                                    validator: _model
-                                        .emailAddressTextControllerValidator
-                                        .asValidator(context),
+                                    validator: (value) {
+                                      if (value == null ||
+                                          !actions.validarEmail(value)) {
+                                        return 'Email no valido';
+                                      }
+                                      return null;
+                                    },
                                   ),
                                 ),
                               ),


### PR DESCRIPTION
## Summary
- add utility to validate email format
- export new function in custom actions index
- show validation message in sign-in page
- show validation message in registration form

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685597318c7c832bbac04916f46e69da